### PR TITLE
Replace product buttons with clickable product preview

### DIFF
--- a/online-shopping-website/src/App.css
+++ b/online-shopping-website/src/App.css
@@ -4,18 +4,12 @@
 
 /* Product grid styles */
 .ProductContainer {
-    padding: 0.5em 1.75em;
+    padding: 1.75em;
+    width: 100%;
     height: 100%;
     color: white;
     background-color: #a75e7d;
     border-radius: 15px;
-}
-
-/* Vertically aligns product image of ProductPreview (in ProductGrid) */
-.ProductImageHelper {
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle;
 }
 
 .ProductImage {
@@ -24,7 +18,12 @@
     max-width: 100%;
 }
 
-.ProductButton {
+.ProductPrice {
+    font-size: 1.5em;
+    margin: 0;
+}
+
+/* .ProductButton {
     color: rgb(203, 253, 203);
     border-color: rgb(78, 219, 78);
     transition: 0.3s all ease-in-out;
@@ -41,7 +40,7 @@
 .ProductButton:hover, .ProductButtonContained:hover {
     background-color: rgba(79, 255, 108, 0.198);
     border-color: rgb(122, 218, 122);
-}
+} */
 
 .accordion-width {
     width:100%;

--- a/online-shopping-website/src/App.css
+++ b/online-shopping-website/src/App.css
@@ -20,7 +20,7 @@
 
 .ProductImage {
     vertical-align: middle;
-    max-height: 200px;
+    height: 200px;
     max-width: 100%;
 }
 

--- a/online-shopping-website/src/App.css
+++ b/online-shopping-website/src/App.css
@@ -23,6 +23,7 @@
     margin: 0;
 }
 
+/* Button styles may be used for other pages */
 /* .ProductButton {
     color: rgb(203, 253, 203);
     border-color: rgb(78, 219, 78);

--- a/online-shopping-website/src/App.css
+++ b/online-shopping-website/src/App.css
@@ -4,7 +4,7 @@
 
 /* Product grid styles */
 .ProductContainer {
-    padding: 0.75em;
+    padding: 0.5em 1.75em;
     height: 100%;
     color: white;
     background-color: #a75e7d;
@@ -32,6 +32,10 @@
 
 .ProductButtonContained {
     background-color: rgb(72, 136, 72);
+}
+
+.ProductButton, .ProductButtonContained {
+    height: 3em;
 }
 
 .ProductButton:hover, .ProductButtonContained:hover {

--- a/online-shopping-website/src/Components/ProductGrid.js
+++ b/online-shopping-website/src/Components/ProductGrid.js
@@ -1,36 +1,32 @@
 import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import React from 'react';
+import Stack from '@mui/material/Stack';
 
 const ProductPreview = (props) => {
   return (
     <Card className="ProductContainer">
-      <Grid container>
-        {/* First column of Product Card. Image renders on top of Card on lg and smaller screens. Renders on the left for lg and xl screens. */}
-        <Grid item xs={12} xl={6} sx={{ textAlign: 'center' }}>
+      <Stack direction="column" justifyContent="space-between">
+        {/* First column of Product Card. Image renders on top of Card */}
+        <Stack direction="row" justifyContent="center" sx={{ textAlign: 'center' }}>
           <div className="ProductImageHelper"></div>
           <img className="ProductImage" src={props.product.image} alt={props.product.name} />
-        </Grid>
+        </Stack>
 
         {/* Second column. Contains all text and Buttons. */}
-        <Grid item xs={12} sm container>
-          <Grid item container direction="column">
-            <Grid item xs sx={{ paddingX: '10px' }}>
-              <h3>{props.product.name}</h3>
-              <h4>Brand: {props.product.brand}</h4>
-              <p>{props.product.description}</p>
-              <h4>Sold by: {props.product.seller}</h4>
-              <h4>Price: {props.product.price} Ɖ</h4>
-              <CardActions sx={{ marginLeft: '-10px' }}>
-                <Button variant="contained" className="ProductButtonContained">Add to Cart</Button>
-                <Button variant="outlined" className="ProductButton">Learn More</Button>
-              </CardActions>
-            </Grid>
-          </Grid>
-        </Grid>
-      </Grid>
+        <Stack spacing={2} direction="column" justifyContent="space-between">
+            <h3>{props.product.name}</h3>
+            <h4>Brand: {props.product.brand}</h4>
+            <p>{props.product.description}</p>
+            <h4>Sold by: {props.product.seller}</h4>
+            <h4>Price: {props.product.price} Ɖ</h4>
+        </Stack>
+        <Stack spacing={1} sx={{width: '100%', paddingY: '20px'}}>
+          <Button variant="contained" className="ProductButtonContained">Add to Cart</Button>
+          <Button variant="outlined" className="ProductButton">Learn More</Button>
+        </Stack>
+      </Stack>
     </Card>
   );
 }

--- a/online-shopping-website/src/Components/ProductGrid.js
+++ b/online-shopping-website/src/Components/ProductGrid.js
@@ -8,13 +8,13 @@ const ProductPreview = (props) => {
   return (
     <Card className="ProductContainer">
       <Stack direction="column" justifyContent="space-between">
-        {/* First column of Product Card. Image renders on top of Card */}
+        {/* Image */}
         <Stack direction="row" justifyContent="center" sx={{ textAlign: 'center' }}>
           <div className="ProductImageHelper"></div>
           <img className="ProductImage" src={props.product.image} alt={props.product.name} />
         </Stack>
 
-        {/* Second column. Contains all text and Buttons. */}
+        {/* Product information */}
         <Stack spacing={2} direction="column" justifyContent="space-between">
             <h3>{props.product.name}</h3>
             <h4>Brand: {props.product.brand}</h4>
@@ -22,6 +22,8 @@ const ProductPreview = (props) => {
             <h4>Sold by: {props.product.seller}</h4>
             <h4>Price: {props.product.price} Ɖ</h4>
         </Stack>
+
+        {/* Buttons */}
         <Stack spacing={1} sx={{width: '100%', paddingY: '20px'}}>
           <Button variant="contained" className="ProductButtonContained">Add to Cart</Button>
           <Button variant="outlined" className="ProductButton">Learn More</Button>

--- a/online-shopping-website/src/Components/ProductGrid.js
+++ b/online-shopping-website/src/Components/ProductGrid.js
@@ -1,35 +1,32 @@
 import Card from '@mui/material/Card';
 import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
 import Grid from '@mui/material/Grid';
 import React from 'react';
 import Stack from '@mui/material/Stack';
 
 const ProductPreview = (props) => {
   return (
-    <Card className="ProductContainer">
-      <Stack sx={{ height: '100%' }} direction="column" justifyContent="space-between">
-        {/* Image */}
-        <Stack direction="row" justifyContent="center" sx={{ textAlign: 'center' }}>
-          <div className="ProductImageHelper"></div>
-          <img className="ProductImage" src={props.product.image} alt={props.product.name} />
-        </Stack>
+    <ButtonBase sx={{ width: '100%', textAlign: 'left', margin: 0, padding: 0, borderRadius: '15px'}} >
+      <Card className="ProductContainer">
+        <Stack sx={{ height: '100%' }} direction="column" justifyContent="space-between">
+          {/* Image */}
+          <Stack direction="row" justifyContent="center" sx={{ textAlign: 'center' }}>
+            <img className="ProductImage" src={props.product.image} alt={props.product.name} />
+          </Stack>
 
-        {/* Product information */}
-        <Stack spacing={2} direction="column" justifyContent="space-between">
+          {/* Product information */}
+          <div>
             <h3>{props.product.name}</h3>
-            <h4>Brand: {props.product.brand}</h4>
-            <p>{props.product.description}</p>
-            <h4>Sold by: {props.product.seller}</h4>
-            <h4>Price: {props.product.price} Ɖ</h4>
-        </Stack>
+            <p>Brand: {props.product.brand}</p>
+            <p>Sold by: {props.product.seller}</p>
+          </div>
 
-        {/* Buttons */}
-        <Stack spacing={1} sx={{width: '100%', paddingY: '20px'}}>
-          <Button variant="contained" className="ProductButtonContained">Add to Cart</Button>
-          <Button variant="outlined" className="ProductButton">Learn More</Button>
+          {/* Product price */}
+          <h4 className="ProductPrice">{props.product.price} Ɖ</h4>
         </Stack>
-      </Stack>
-    </Card>
+      </Card>
+    </ButtonBase>
   );
 }
 
@@ -46,7 +43,7 @@ const iterateProducts = (data) => {
 
 export const ProductGrid = (props) => { 
   return (
-    <Grid container spacing={5} rowSpacing={8}>
+    <Grid container spacing={5} rowSpacing={5}>
       {iterateProducts(props)}
     </Grid>
   );

--- a/online-shopping-website/src/Components/ProductGrid.js
+++ b/online-shopping-website/src/Components/ProductGrid.js
@@ -7,7 +7,7 @@ import Stack from '@mui/material/Stack';
 const ProductPreview = (props) => {
   return (
     <Card className="ProductContainer">
-      <Stack direction="column" justifyContent="space-between">
+      <Stack sx={{ height: '100%' }} direction="column" justifyContent="space-between">
         {/* Image */}
         <Stack direction="row" justifyContent="center" sx={{ textAlign: 'center' }}>
           <div className="ProductImageHelper"></div>

--- a/online-shopping-website/src/Components/ProductGrid.js
+++ b/online-shopping-website/src/Components/ProductGrid.js
@@ -1,5 +1,4 @@
 import Card from '@mui/material/Card';
-import Button from '@mui/material/Button';
 import ButtonBase from '@mui/material/ButtonBase';
 import Grid from '@mui/material/Grid';
 import React from 'react';

--- a/online-shopping-website/src/index.css
+++ b/online-shopping-website/src/index.css
@@ -9,6 +9,10 @@ h1, h2, h3 {
   font-weight: 300;
 }
 
+h3 {
+  font-size: 1.5em;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/online-shopping-website/src/index.js
+++ b/online-shopping-website/src/index.js
@@ -6,11 +6,9 @@ import { StyledEngineProvider } from '@mui/material/styles';
 // import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
-  <React.StrictMode>
-    <StyledEngineProvider injectFirst>
-      <App />
-    </StyledEngineProvider>
-  </React.StrictMode>,
+  <StyledEngineProvider injectFirst>
+    <App />
+  </StyledEngineProvider>,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
## Brief Description
Replaced product buttons with clickable product preview.

## Linked Issues
- closes #39 

## Changes
- Removed product buttons (Add to Cart, View More)
- Used `<ButtonBase>` to make product preview clickable
   - Will route to product full page when routing is ready
- Increased font size of price
- Decreased font size of brands and sellers
- Used Stack component to vertically stack items
   - Stacked product information
- Put product image above product information for all screens
   - Product image stays above product information for all screen sizes, rather than lg or smaller
- Increased consistency when filtering data (less vertical movement and adjustments)
- Fixed h3 size
- Fixed padding
- Aligned all product images with static height


## Additional context
Commented styles in App.css may be used for styling buttons on other pages.