### PR TITLE
Fixed frontend path typo

### DIFF
--- a/.github/workflows/FrontendCD.yml
+++ b/.github/workflows/FrontendCD.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [ master ]
     paths:
-      - "online-shopping-website/fronend/**"
+      - "online-shopping-website/frontend/**"
 
 jobs:
   build:


### PR DESCRIPTION
## Brief Description
Fixed FrontendCD typo, blocking CD from occurring

## Changes
- Fixed frontend path spelling (fronend instead of fron***t***end)

## Additional context
Koosha was confuzzled 🙈😵