### PR TITLE
Remove unnecessary promotion from cart

### DIFF
--- a/online-shopping-website/frontend/src/Components/CartPage.js
+++ b/online-shopping-website/frontend/src/Components/CartPage.js
@@ -181,8 +181,7 @@ export const CartPage = (props) => {
 
                                     {/*Price info*/}
                                     <Grid item xs={12} lg={3}>
-                                        <h4 style={{margin: 0}}>Price: {item.price} Ɖ</h4>
-                                        <h4>Promotion: 20% off</h4>
+                                        <h4 style={{margin: 0, fontSize: '24px'}}>Price: {item.price} Ɖ</h4>
                                     </Grid>
 
                                     {/*Quantity buttons*/}


### PR DESCRIPTION
## Brief Description
Removed "Promotion: 20% off" text from products on cart page

## Changes
- Removed heading with static "Promotion: 20% off" text from products on cart page
- Increased price heading size to 24px