### PR TITLE
Item quantities go down when an order is made

### DIFF
--- a/online-shopping-website/backend/prisma/migrations/20220403223236_total_quantity_required/migration.sql
+++ b/online-shopping-website/backend/prisma/migrations/20220403223236_total_quantity_required/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `totalQuantity` on table `Item` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Item" ALTER COLUMN "totalQuantity" SET NOT NULL;

--- a/online-shopping-website/backend/prisma/schema.prisma
+++ b/online-shopping-website/backend/prisma/schema.prisma
@@ -61,7 +61,7 @@ model Item {
   brandId       Int
   seller        User    @relation(fields: [sellerId], references: [id])
   sellerId      Int
-  totalQuantity Int?
+  totalQuantity Int
 }
 
 model Brand {

--- a/online-shopping-website/backend/src/helpers/verifyItemQuantitiesForOrder.ts
+++ b/online-shopping-website/backend/src/helpers/verifyItemQuantitiesForOrder.ts
@@ -1,0 +1,9 @@
+import { Item } from '@prisma/client';
+
+export default async function thereIsEnoughItemQuantities(args: {items: Item[], itemQuantities: number[]}){ //this check is meant to see if there are enough item quantities for every item in an order
+  let flag = true;
+  args.items.forEach((item, index) => {
+    if (item.totalQuantity < args.itemQuantities[index]) {flag = false;}
+  });
+  return flag;
+}

--- a/online-shopping-website/backend/src/prismaFunctions/itemFuncs.ts
+++ b/online-shopping-website/backend/src/prismaFunctions/itemFuncs.ts
@@ -7,9 +7,9 @@ export async function createItem(args: {
   picture: string;
   brandId: number;
   sellerId: number;
+  totalQuantity: number;
   promoted?: boolean;
   salePrice?: number;
-  totalQuantity?: number;
 }) {
   return await prisma.item.create({
     data: {
@@ -80,6 +80,16 @@ export async function itemById(args: { id: number }) {
   });
 }
 
+export async function manyItemsById(args: { ids: number[]}){
+  return await prisma.item.findMany({
+    where: {
+      id: {
+        in: args.ids
+      },
+    },
+  });
+}
+
 export async function itemByName(args: { name: string }) {
   return prisma.item.findMany({
     where: {
@@ -136,6 +146,9 @@ export async function findItems(args: { name?: string; sellerId?: number; brandI
           name: true
         },
       },
+    },
+    orderBy: {
+      id: 'asc'
     },
   });
 }

--- a/online-shopping-website/backend/src/prismaFunctions/orderFuncs.ts
+++ b/online-shopping-website/backend/src/prismaFunctions/orderFuncs.ts
@@ -6,6 +6,17 @@ export async function createOrder(args: {
   itemQuantities: number[];
   totalPrice: number;
 }) {
+  args.itemIds.forEach(async (itemId, index) => {
+    await prisma.item.update({
+      where: { id: itemId },
+      data: {
+        totalQuantity: {
+          decrement: args.itemQuantities[index],
+        },
+      },
+    });
+  });
+
   return await prisma.order.create({
     data: {
       itemQuantities: args.itemQuantities,


### PR DESCRIPTION
Quantities on items now change and orders cannot be made if the quantity would go to negative. Also made items in seller in order of id

## Brief Description
Quantities on items now change and orders cannot be made if the quantity would go to negative. Also made items in seller in order of id

## Linked Issues
- closes #140 

## Changes
- Items now need a quantity to be created
- Backend now decrements the `totalQuantity` property of all items that were in the order based on the item quantities that are part of the order
- Backend now checks whether there are enough of all items in the order to create the order without having a negative quantity

## Acceptance Criteria
- [ ] Test coverage >80%
- [ ] All specifications met in feature requirements

