### PR TITLE
Displays message when add to cart is disabled for non-customers

### DIFF
--- a/online-shopping-website/frontend/src/Components/Browse/Products/ProductDetails.js
+++ b/online-shopping-website/frontend/src/Components/Browse/Products/ProductDetails.js
@@ -149,6 +149,15 @@ const ProductButtons = (props) => {
                 onClick={AddToCart}>
                 Add to cart
             </Button>
+            {
+                // Explain to non-customers that they do not have access to add to cart
+                !cookies.user &&
+                <h5 className="ProductDetails-ProductLimitText">You must be logged in to add to cart.</h5>
+            }
+            {
+                cookies.user && cookies.user.user.role !== 'CUSTOMER' &&
+                <h5 className="ProductDetails-ProductLimitText">Only customers may add to cart.</h5>
+            }
         </div>
     );
 }

--- a/online-shopping-website/frontend/src/Components/Browse/Products/ProductDetails.js
+++ b/online-shopping-website/frontend/src/Components/Browse/Products/ProductDetails.js
@@ -150,11 +150,12 @@ const ProductButtons = (props) => {
                 Add to cart
             </Button>
             {
-                // Explain to non-customers that they do not have access to add to cart
+                // Logged out users may not add to cart
                 !cookies.user &&
                 <h5 className="ProductDetails-ProductLimitText">You must be logged in to add to cart.</h5>
             }
             {
+                // Non-customers may not add to cart
                 cookies.user && cookies.user.user.role !== 'CUSTOMER' &&
                 <h5 className="ProductDetails-ProductLimitText">Only customers may add to cart.</h5>
             }


### PR DESCRIPTION
## Brief Description
Display message underneath disabled add to cart button.

## Linked Issues
- [ ] #162 

## Changes
- If user is logged out, display message: "You must be logged in to add to cart."
- If user is logged in, but not a customer, display message: "Only customers may add to cart."