### PR TITLE
Add promoted toggle

### DIFF
--- a/online-shopping-website/backend/src/prismaFunctions/itemFuncs.ts
+++ b/online-shopping-website/backend/src/prismaFunctions/itemFuncs.ts
@@ -84,7 +84,22 @@ export async function itemById(args: { id: number }) {
 
 export async function promotedItems(){
   return prisma.item.findMany({
-    where: { promoted: true },
+    where: { 
+      promoted: true,
+      active: true
+    },
+    include:{
+      seller: {
+        select:{
+          sellerName: true
+        }
+      },
+      brand: {
+        select:{
+          name: true
+        }
+      }
+    }
   });
 }
 

--- a/online-shopping-website/frontend/src/Components/Seller/SellerProductsForm.js
+++ b/online-shopping-website/frontend/src/Components/Seller/SellerProductsForm.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createRef, useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { Button, InputAdornment, Stack, TextField } from '@mui/material';
+import { Button, InputAdornment, Stack, TextField, Checkbox, FormControlLabel } from '@mui/material';
 import { useCookies } from 'react-cookie';
 import UploadIcon from '@mui/icons-material/Upload';
 import axios from 'axios';
@@ -48,7 +48,8 @@ export const SellerForm = () => {
                 description: '',
                 brand: { name: '' },
                 seller: { sellerName: cookies.user.user.sellerName },
-                totalQuantity: ''
+                totalQuantity: '',
+                promoted: false
             })
             setLoading(false);
         }
@@ -86,6 +87,18 @@ export const SellerForm = () => {
             });
         }
     }
+
+    const handleCheckBoxChange = (event) => {
+        console.log(`Before: ${productData.promoted}`)
+        if (event.target.name === "promoted") {
+            setProductData({
+                ...productData,
+                [event.target.name]: event.target.checked
+            });
+        }
+        console.log(`After: ${productData.promoted}`)
+        //console.log(productData);
+    };
 
     // Triggers when new image is uploaded
     const handleImageChange = (e) => {
@@ -255,6 +268,20 @@ export const SellerForm = () => {
                     value={productData.totalQuantity}
                     onChange={handleFieldChange}
                 />
+                <FormControlLabel 
+                    value="promoted"
+                    control={
+                        <Checkbox 
+                        checked={productData.promoted}
+                        name="promoted"
+                        onChange={handleCheckBoxChange}
+                        />
+                    }
+                    label="Promote Item"
+                    labelPlacement='start'
+                    style={{ flexDirection: "row"}}
+                />
+                
                 <Button type="submit" variant="contained" className="GreenButtonContained"
                     style={{ width: "fit-content", margin: "1rem auto" }}>
                     Save Changes

--- a/online-shopping-website/frontend/src/Components/Seller/SellerProductsForm.js
+++ b/online-shopping-website/frontend/src/Components/Seller/SellerProductsForm.js
@@ -89,15 +89,12 @@ export const SellerForm = () => {
     }
 
     const handleCheckBoxChange = (event) => {
-        console.log(`Before: ${productData.promoted}`)
         if (event.target.name === "promoted") {
             setProductData({
                 ...productData,
                 [event.target.name]: event.target.checked
             });
         }
-        console.log(`After: ${productData.promoted}`)
-        //console.log(productData);
     };
 
     // Triggers when new image is uploaded

--- a/online-shopping-website/frontend/src/Components/Seller/SellerProductsForm.js
+++ b/online-shopping-website/frontend/src/Components/Seller/SellerProductsForm.js
@@ -272,6 +272,7 @@ export const SellerForm = () => {
                         checked={productData.promoted}
                         name="promoted"
                         onChange={handleCheckBoxChange}
+                        sx={{ '&.Mui-checked': { color: 'rgb(60, 121, 60)' } }}
                         />
                     }
                     label="Promote Item"


### PR DESCRIPTION
## Brief Description
Added the promoted toggle to items so that they can be shown on the promoted items list

## Linked Issues
- closes #163 

## Changes
- Added checkbox to `productForm` that toggles an item's promoted status
- Added seller and brand information to promoted items route

## Acceptance Criteria
- [x] Test coverage >80%
- [x] All specifications met in feature requirements

