### PR TITLE
Persist cookies between visits

### DIFF
--- a/online-shopping-website/frontend/src/App.js
+++ b/online-shopping-website/frontend/src/App.js
@@ -1,4 +1,5 @@
 import './App.css';
+import React from 'react';
 import NavBar from './Components/NavBar';
 import { SellerProductsPage } from './Components/Seller/SellerProductsPage';
 import { SellerForm } from './Components/Seller/SellerProductsForm';
@@ -7,11 +8,9 @@ import { ProductDetails } from './Components/Browse/Products/ProductDetails';
 import { CartPage } from './Components/Browse/CartPage';
 import { Register } from './Components/Profile/RegisterPage';
 import { BrowserRouter, Outlet, Routes, Route } from "react-router-dom";
-import { useCookies } from "react-cookie";
 import { ProfilePage } from "./Components/Profile/ProfilePage";
 import { ViewOrders } from "./Components/Profile/ViewOrders";
 import { AdminPage } from "./Components/Profile/AdminPage";
-
 
 const Layout = () => {
     return (
@@ -24,11 +23,7 @@ const Layout = () => {
     );
 };
 
-
 export default function App() {
-    const [cartCookie, setCookie] = useCookies(["cart"]);
-
-
     return (
         <BrowserRouter>
             <Routes>

--- a/online-shopping-website/frontend/src/Components/Browse/CartPage.js
+++ b/online-shopping-website/frontend/src/Components/Browse/CartPage.js
@@ -1,4 +1,5 @@
 import {useState, useEffect} from 'react';
+import { cookieAge } from './CookieAge';
 import axios from 'axios';
 
 import Grid from '@mui/material/Grid';
@@ -38,14 +39,14 @@ export const CartPage = () => {
                 return response.data.some((product) => {
                     return product.id === cartProduct.id;
                 })
-            }));
+            }), { maxAge: cookieAge });
 
             // Update cart items with new product data
             setCookie("cart", cookies.cart.map((cartProduct) => {
                 return Object.assign(cartProduct, response.data.find(product => (
                     product.id === cartProduct.id
                 )));
-            }));
+            }), { maxAge: cookieAge });
         });
     }, []);
 
@@ -122,7 +123,7 @@ export const CartPage = () => {
                     return {...product, quantity: quantity};
                 }
                 return product;
-            }));
+            }), { maxAge: cookieAge });
         }
 
         function IncrementItem(item) {
@@ -143,7 +144,7 @@ export const CartPage = () => {
 
         function RemoveItem(itemID) {
             //Creates new array containing every product in the cart except the one being removed
-            setCookie("cart", cookies.cart.filter(product => product.id !== itemID));
+            setCookie("cart", cookies.cart.filter(product => product.id !== itemID), { maxAge: cookieAge });
             forceUpdate();
         }
 

--- a/online-shopping-website/frontend/src/Components/Browse/CookieAge.js
+++ b/online-shopping-website/frontend/src/Components/Browse/CookieAge.js
@@ -1,0 +1,2 @@
+// Set all cookies to delete after a week. This value will change all cookie ages in the application.
+export const cookieAge = 60 * 60 * 24 * 7;

--- a/online-shopping-website/frontend/src/Components/Browse/Products/ProductDetails.js
+++ b/online-shopping-website/frontend/src/Components/Browse/Products/ProductDetails.js
@@ -1,3 +1,4 @@
+import { cookieAge } from '../CookieAge';
 import Grid from '@mui/material/Grid';
 import Card from '@mui/material/Card';
 import * as React from 'react';
@@ -50,7 +51,7 @@ const ProductButtons = (props) => {
                 return { ...product, quantity: newQuantity };
             }
             return product;
-        }));
+        }), { maxAge: cookieAge });
     }
 
     const AddToCart = () => {
@@ -73,7 +74,7 @@ const ProductButtons = (props) => {
             }
 
             //setting cookie to the new created item
-            setCookie("cart", [newCartItem]);
+            setCookie("cart", [newCartItem], { maxAge: cookieAge });
         }
 
         // Item already in cart
@@ -102,7 +103,7 @@ const ProductButtons = (props) => {
                 newCartItem
             );
 
-            setCookie("cart", cookies.cart);
+            setCookie("cart", cookies.cart, { maxAge: cookieAge });
         }
     }
 

--- a/online-shopping-website/frontend/src/Components/NavBar.js
+++ b/online-shopping-website/frontend/src/Components/NavBar.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { cookieAge } from './Browse/CookieAge';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
@@ -68,7 +69,9 @@ export default function NavBar() {
         try {
             const loginResponse = await axios.post(process.env.REACT_APP_DB_CONNECTION + "/api/users/signin", user);
 
-            setCookie('user', loginResponse.data);
+            setCookie('user', loginResponse.data, {
+                maxAge: cookieAge
+            });
 
             // Close login popup
             setOpenLogin(false);

--- a/online-shopping-website/frontend/src/Components/Profile/AdminPage.js
+++ b/online-shopping-website/frontend/src/Components/Profile/AdminPage.js
@@ -47,7 +47,7 @@ export const AdminPage = () => {
         },
     ]
 
-    const [cookies, setCookies] = useCookies(['user']);
+    const [cookies] = useCookies(['user']);
     const [users, setUsers] = useState([]);
     const [loading, setLoading] = useState(true);
 

--- a/online-shopping-website/frontend/src/Components/Profile/ProfilePage.js
+++ b/online-shopping-website/frontend/src/Components/Profile/ProfilePage.js
@@ -1,3 +1,4 @@
+import { cookieAge } from '../Browse/CookieAge';
 import * as React from 'react';
 import { useState } from 'react';
 import Button from "@mui/material/Button";
@@ -38,7 +39,7 @@ export const ProfilePage = () => {
                 (err.response.data.message ? err.response.data.message + "." : ""));
         }
 
-        setCookie("user", updateProfileResponse.data);
+        setCookie("user", updateProfileResponse.data, { maxAge: cookieAge });
         setEditable(false);
     }
 

--- a/online-shopping-website/frontend/src/Components/Profile/ViewOrders.js
+++ b/online-shopping-website/frontend/src/Components/Profile/ViewOrders.js
@@ -19,7 +19,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { SearchBar } from '../Browse/Products/SearchBar';
 
 export const ViewOrders = () => {
-    const [cookie, setCookie] = useCookies(['user']);
+    const [cookie] = useCookies(['user']);
 
     let [searchFilter] = useState({searchQuery: ''});
     const [unfilteredOrders, setUnfilteredOrders] = useState(null);

--- a/online-shopping-website/frontend/src/Components/Seller/SellerProductsPage.js
+++ b/online-shopping-website/frontend/src/Components/Seller/SellerProductsPage.js
@@ -65,7 +65,7 @@ export const SellerProductsPage = () => {
         },
         { field: 'totalQuantity', headerName: 'Quantity', type: 'number', width: 100 }
     ];
-    const [cookies, setCookies] = useCookies(['user']);
+    const [cookies] = useCookies(['user']);
 
     const [loading, setLoading] = useState(true);
     const [sellers, setSellers] = useState([]);

--- a/online-shopping-website/frontend/src/index.js
+++ b/online-shopping-website/frontend/src/index.js
@@ -3,20 +3,13 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import { StyledEngineProvider } from '@mui/material/styles';
-// import reportWebVitals from './reportWebVitals';
 import { CookiesProvider } from "react-cookie";
-
 
 ReactDOM.render(
   <StyledEngineProvider injectFirst>
     <CookiesProvider>
-    <App />
-  </CookiesProvider>
+      <App />
+    </CookiesProvider>
   </StyledEngineProvider>,
   document.getElementById('root')
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-// reportWebVitals();


### PR DESCRIPTION
## Brief Description
Correctly persists cookies for a chosen amount of time on the user's system.

## Changes
- Created CookieAge.js which exports `cookieAge` variable
   - Acts as a global variable for any components that import it
   - Set as 7 days, but if adjusted, will carry throughout application
- Removed some unused imports
- Removed unused variables when using cookies (Removed some `setCookie` variables)

## Acceptance Tests
- [X] When user logs in and closes their browser, they will stay logged in on the next visit
- [X] When customer adds items to their cart and closes their browser, their cart will persist in future visits

## Additional context
While the cookies persist correctly, the JWT authentication tokens may be invalidated after a day or two anyways, forcing the user to log in again.
