### PR TITLE
Fixed NavBar user menu links

### DIFF
--- a/online-shopping-website/frontend/src/Components/NavBar.js
+++ b/online-shopping-website/frontend/src/Components/NavBar.js
@@ -189,8 +189,16 @@ export default function NavBar() {
                                 onClose={handleCloseUserMenu}
                             >
                                 {cookies.user.user.username && (<Typography style={{padding:"0.3rem 1rem"}}>Hi, {cookies.user.user.username}</Typography>)}
-                                <Link className='RoutingLink' to='profile'><MenuItem onClick={handleCloseUserMenu}>Profile</MenuItem></Link>
-                                <Link className='RoutingLink' to='view-orders'><MenuItem onClick={handleCloseUserMenu}>My Orders</MenuItem></Link>
+                                <Link className='RoutingLink' to='profile'>
+                                    <MenuItem onClick={handleCloseUserMenu}>
+                                        Profile
+                                    </MenuItem>
+                                </Link>
+                                <Link className='RoutingLink' to='view-orders'>
+                                    <MenuItem onClick={handleCloseUserMenu}>
+                                        My Orders
+                                    </MenuItem>
+                                </Link>
                                 <MenuItem onClick={handleLogout}>Logout</MenuItem>
                             </Menu>
                         </div>
@@ -225,10 +233,21 @@ export default function NavBar() {
                                 onClose={handleCloseUserMenu}
                             >
                                 {cookies.user.user.username && (<Typography style={{padding:"0.3rem 1rem"}}>Hi, {cookies.user.user.username}</Typography>)}
-                                <Link className='RoutingLink' to='profile'><MenuItem onClick={handleCloseUserMenu}>Profile</MenuItem></Link>
-                                <Link className='RoutingLink' to='view-orders'><MenuItem className='RoutingLink' onClick={handleCloseUserMenu}>Manage Orders</MenuItem></Link>
-                                <MenuItem className='RoutingLink' onClick={handleCloseUserMenu}><Link className='RoutingLink' to="/seller">Manage
-                                    Products</Link></MenuItem>
+                                <Link className='RoutingLink' to='profile'>
+                                    <MenuItem onClick={handleCloseUserMenu}>
+                                        Profile
+                                    </MenuItem>
+                                </Link>
+                                <Link className='RoutingLink' to='view-orders'>
+                                    <MenuItem className='RoutingLink' onClick={handleCloseUserMenu}>
+                                        Manage Orders
+                                    </MenuItem>
+                                </Link>
+                                <Link className='RoutingLink' to="/seller">
+                                    <MenuItem className='RoutingLink' onClick={handleCloseUserMenu}>
+                                        Manage Products
+                                    </MenuItem>
+                                </Link>
                                 <MenuItem onClick={handleLogout}>Logout</MenuItem>
                             </Menu>
                         </div>
@@ -263,9 +282,21 @@ export default function NavBar() {
                                 onClose={handleCloseUserMenu}
                             >
                                 {cookies.user.user.username && (<Typography style={{padding:"0.3rem 1rem"}}>Hi, {cookies.user.user.username}</Typography>)}
-                                <Link className='RoutingLink' to='profile'><MenuItem onClick={handleCloseUserMenu}>Profile</MenuItem></Link>
-                                <MenuItem onClick={handleCloseUserMenu}><Link className='RoutingLink' to='/admin'>Admin Page</Link></MenuItem> {/*Admin page*/}
-                                <MenuItem onClick={handleCloseUserMenu}><Link className='RoutingLink' to='admin/seller'>View All Products</Link></MenuItem>
+                                <Link className='RoutingLink' to='profile'>
+                                    <MenuItem onClick={handleCloseUserMenu}>
+                                        Profile
+                                    </MenuItem>
+                                </Link>
+                                <Link className='RoutingLink' to='/admin'>
+                                    <MenuItem onClick={handleCloseUserMenu}>
+                                        Admin Page
+                                    </MenuItem>
+                                </Link>
+                                <Link className='RoutingLink' to='admin/seller'>
+                                    <MenuItem onClick={handleCloseUserMenu}>
+                                       Manage Products
+                                    </MenuItem>
+                                </Link>
                                 <MenuItem onClick={handleLogout}>Logout</MenuItem>
                             </Menu>
                         </div>


### PR DESCRIPTION
## Brief Description
Fixed NavBar clickable links and names.

## Changes
- Made all `<Link>` tags surround `<MenuItem>` tags
   - This ensures the clickable region on the NavBar menu is the whole button, not just the word

## Reason
Menu item link didn't link when not clicking the link title.
- For example, an admin wants to visit the "Admin Page" page
   - If they click on the letters "Admin Page" in the link, they will be sent to the admin page.
   - If they click outside of the letters, but inside the link area, they will not be linked anywhere.